### PR TITLE
return value from .set()

### DIFF
--- a/dict.js
+++ b/dict.js
@@ -46,7 +46,7 @@ module.exports = function (initializer) {
                 ++size;
             }
 
-            store[mangled] = value;
+            return store[mangled] = value;
         },
         has: function (key) {
             assertString(key);


### PR DESCRIPTION
This makes .set() return the set value, just like an assignment to an object would.
(I completely understand if you choose not to merge this for cleanliness reasons)
